### PR TITLE
chore(app): commit lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-yarn.lock
-package-lock.json


### PR DESCRIPTION
## Why

Keeping lockfile is necessary for application.

## What

delete lockfile from gitignore.

## Other Information

yarnpkg - Should I commit the yarn.lock file and what is it for? - Stack Overflow https://stackoverflow.com/questions/39990017/should-i-commit-the-yarn-lock-file-and-what-is-it-for
